### PR TITLE
[Feat] 아이디와 비밀번호 생성 규칙 추가

### DIFF
--- a/src/auth/payload/change-password.payload.ts
+++ b/src/auth/payload/change-password.payload.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
+import { MinLength, Matches } from 'class-validator';
 
 export class ChangePasswordPayload {
   @IsString()
@@ -10,6 +11,10 @@ export class ChangePasswordPayload {
   currentPassword!: string;
 
   @IsString()
+  @MinLength(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
+  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).+$/, {
+    message: '비밀번호는 영문 대소문자, 숫자, 특수문자를 모두 포함해야 합니다.',
+  })
   @ApiProperty({
     description: '새 비밀번호',
     type: String,

--- a/src/auth/payload/sign-up.payload.ts
+++ b/src/auth/payload/sign-up.payload.ts
@@ -6,6 +6,9 @@ import {
   IsOptional,
   IsArray,
   IsInt,
+  MinLength,
+  MaxLength,
+  Matches,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Gender as PrismaGender } from '@prisma/client';
@@ -18,6 +21,12 @@ export enum GenderEnum {
 
 export class SignUpPayload {
   @IsString()
+  @MinLength(4, { message: '아이디는 최소 4자 이상이어야 합니다.' })
+  @MaxLength(20, { message: '아이디는 최대 20자까지 가능합니다.' })
+  @Matches(/^[a-z][a-z0-9._]{3,19}$/, {
+    message:
+      '아이디는 최소 4자면서 영문 소문자로 시작하고, 영문 소문자/숫자/밑줄/마침표만 사용할 수 있습니다.',
+  })
   @ApiProperty({
     description: '로그인 ID',
     type: String,
@@ -25,6 +34,10 @@ export class SignUpPayload {
   loginId!: string;
 
   @IsString()
+  @MinLength(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
+  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).+$/, {
+    message: '비밀번호는 영문 대소문자, 숫자, 특수문자를 모두 포함해야 합니다.',
+  })
   @ApiProperty({
     description: '비밀번호',
     type: String,

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -55,6 +55,21 @@ export class UserService {
     const badwords = new BadWordsNext({ data: en });
 
     if (payload.loginId) {
+      if (isReservedUsername(payload.loginId)) {
+        throw new BadRequestException('사용할 수 없는 아이디입니다.');
+      }
+
+      if (hasConsecutiveSpecialChars(payload.loginId)) {
+        throw new BadRequestException(
+          '아이디에 연속된 특수문자는 사용할 수 없습니다.',
+        );
+      }
+
+      if (startsOrEndsWithSpecialChar(payload.loginId)) {
+        throw new BadRequestException(
+          '아이디는 특수문자로 시작하거나 끝날 수 없습니다.',
+        );
+      }
       if (payload.loginId === user.loginId) {
         throw new BadRequestException('현재 사용 중인 로그인 ID와 동일합니다.');
       }
@@ -200,4 +215,18 @@ export class UserService {
   > {
     return this.userRepository.getAllUsersWithParagraphLikes();
   }
+}
+
+const RESERVED_USERNAMES = ['admin', 'root', 'support', 'manager', 'system'];
+
+function isReservedUsername(username: string): boolean {
+  return RESERVED_USERNAMES.includes(username.toLowerCase());
+}
+
+function hasConsecutiveSpecialChars(username: string): boolean {
+  return /[._]{2,}/.test(username); // 연속된 마침표 또는 밑줄
+}
+
+function startsOrEndsWithSpecialChar(username: string): boolean {
+  return /^[._]|[._]$/.test(username); // 시작 또는 끝이 특수문자
 }


### PR DESCRIPTION
1. 아이디 생성 규칙 추가
- 아이디는 최소 4자, 최대 20자
- 아이디는 영문 소문자로 시작하고, 영문 소문자/숫자/밑줄/마침표만 사용 가능

2. 비밀번호 생성 규칙 추가
- 비밀번호는 최소 8자 이상
- 비밀번호는 영문 대소문자, 숫자, 특수문자를 모두 포함해야 함

