### PR TITLE
[Feat] 닉네임 생성 규칙 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -137,17 +137,17 @@ export class AuthController {
     return this.authService.findId(payload);
   }
 
-  @Post('find-password/:loginId')
+  @Post('find-password/:username')
   @HttpCode(204)
   @ApiNoContentResponse()
   @ApiOperation({ summary: '비밀번호 찾기 : 인증번호 이메일 전송' })
-  @ApiParam({ name: 'loginId', required: true, description: '로그인 ID' })
+  @ApiParam({ name: 'username', required: true, description: '로그인 ID' })
   async sendFindPasswordEmail(
-    @Param('loginId') loginId: string,
+    @Param('username') username: string,
     @Body() payload: SendEmailPayload,
   ): Promise<void> {
-    console.log('Sending find password email for loginId:', loginId);
-    return this.authService.sendFindPasswordEmail(loginId, payload);
+    console.log('Sending find password email for username:', username);
+    return this.authService.sendFindPasswordEmail(username, payload);
   }
 
   @Post('verify-password')

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -88,12 +88,15 @@ export class AuthService {
       );
     }
 
-    if (/[-_]{2,}/.test(payload.nickname)) {
+    if (isReservedUsername(payload.nickname)) {
+      throw new BadRequestException('사용할 수 없는 닉네임입니다.');
+    }
+    if (hasConsecutiveSpecialChars(payload.nickname)) {
       throw new BadRequestException(
         '닉네임에 연속된 밑줄(_) 또는 하이픈(-)은 사용할 수 없습니다.',
       );
     }
-    if (/^[-_]|[-_]$/.test(payload.nickname)) {
+    if (startsOrEndsWithSpecialChar(payload.nickname)) {
       throw new BadRequestException(
         '닉네임은 밑줄(_) 또는 하이픈(-)으로 시작하거나 끝날 수 없습니다.',
       );

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -87,6 +87,18 @@ export class AuthService {
         '닉네임에 부적절한 단어가 포함되어 있습니다.',
       );
     }
+
+    if (/[-_]{2,}/.test(payload.nickname)) {
+      throw new BadRequestException(
+        '닉네임에 연속된 밑줄(_) 또는 하이픈(-)은 사용할 수 없습니다.',
+      );
+    }
+    if (/^[-_]|[-_]$/.test(payload.nickname)) {
+      throw new BadRequestException(
+        '닉네임은 밑줄(_) 또는 하이픈(-)으로 시작하거나 끝날 수 없습니다.',
+      );
+    }
+
     const email = await this.authRepository.getUserByEmail(payload.email);
     if (email) {
       throw new ConflictException('이미 사용중인 이메일입니다.');

--- a/src/auth/payload/change-password.payload.ts
+++ b/src/auth/payload/change-password.payload.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { IsString, MaxLength } from 'class-validator';
 import { MinLength, Matches } from 'class-validator';
 
 export class ChangePasswordPayload {
@@ -12,6 +12,7 @@ export class ChangePasswordPayload {
 
   @IsString()
   @MinLength(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
+  @MaxLength(50, { message: '비밀번호는 최대 50자까지 가능합니다.' })
   @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).+$/, {
     message: '비밀번호는 영문 대소문자, 숫자, 특수문자를 모두 포함해야 합니다.',
   })

--- a/src/auth/payload/sign-up.payload.ts
+++ b/src/auth/payload/sign-up.payload.ts
@@ -34,6 +34,7 @@ export class SignUpPayload {
 
   @IsString()
   @MinLength(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
+  @MaxLength(50, { message: '비밀번호는 최대 50자까지 가능합니다.' })
   @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).+$/, {
     message: '비밀번호는 영문 대소문자, 숫자, 특수문자를 모두 포함해야 합니다.',
   })
@@ -44,6 +45,12 @@ export class SignUpPayload {
   password!: string;
 
   @IsString()
+  @MinLength(2, { message: '닉네임은 최소 2자 이상이어야 합니다.' })
+  @MaxLength(20, { message: '닉네임은 최대 20자까지 가능합니다.' })
+  @Matches(/^[가-힣a-zA-Z0-9_-]{2,20}$/, {
+    message:
+      '닉네임은 한글, 영문, 숫자, 밑줄(_) 또는 하이픈(-)만 사용할 수 있습니다.',
+  })
   @ApiProperty({
     description: '닉네임',
     type: String,

--- a/src/user/payload/update-user.payload.ts
+++ b/src/user/payload/update-user.payload.ts
@@ -34,6 +34,12 @@ export class UpdateUserPayload {
 
   @IsOptional()
   @IsString()
+  @MinLength(2, { message: '닉네임은 최소 2자 이상이어야 합니다.' })
+  @MaxLength(20, { message: '닉네임은 최대 20자까지 가능합니다.' })
+  @Matches(/^[가-힣a-zA-Z0-9_-]{2,20}$/, {
+    message:
+      '닉네임은 한글, 영문, 숫자, 밑줄(_) 또는 하이픈(-)만 사용할 수 있습니다.',
+  })
   @Transform(({ value }) => (value === '' ? undefined : value))
   @ApiPropertyOptional({
     description: '닉네임',

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -115,6 +115,16 @@ export class UserService {
           '닉네임에 부적절한 단어가 포함되어 있습니다.',
         );
       }
+      if (/[-_]{2,}/.test(payload.nickname)) {
+        throw new BadRequestException(
+          '닉네임에 연속된 밑줄(_) 또는 하이픈(-)은 사용할 수 없습니다.',
+        );
+      }
+      if (/^[-_]|[-_]$/.test(payload.nickname)) {
+        throw new BadRequestException(
+          '닉네임은 밑줄(_) 또는 하이픈(-)으로 시작하거나 끝날 수 없습니다.',
+        );
+      }
     }
     if (payload.birthday) {
       if (payload.birthday > new Date()) {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -115,14 +115,17 @@ export class UserService {
           '닉네임에 부적절한 단어가 포함되어 있습니다.',
         );
       }
-      if (/[-_]{2,}/.test(payload.nickname)) {
+      if (isReservedUsername(payload.nickname)) {
+        throw new BadRequestException('사용할 수 없는 닉네임입니다.');
+      }
+      if (hasConsecutiveSpecialChars(payload.nickname)) {
         throw new BadRequestException(
-          '닉네임에 연속된 밑줄(_) 또는 하이픈(-)은 사용할 수 없습니다.',
+          '닉네임에 연속된 특수문자는 사용할 수 없습니다.',
         );
       }
-      if (/^[-_]|[-_]$/.test(payload.nickname)) {
+      if (startsOrEndsWithSpecialChar(payload.nickname)) {
         throw new BadRequestException(
-          '닉네임은 밑줄(_) 또는 하이픈(-)으로 시작하거나 끝날 수 없습니다.',
+          '닉네임은 특수문자로 시작하거나 끝날 수 없습니다.',
         );
       }
     }


### PR DESCRIPTION
- 닉네임은 최소 2자, 최대 20자
- 닉네임은 한글, 영문, 숫자, 밑줄(_) 또는 하이픈(-)만 사용 가능

- 추가적으로 비밀번호 생성에 최대 50자 규칙 추가