### PR TITLE
[Feat] 검색어 자동완성 수정 & 책 조회수 증가 api 구현

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,9 @@
-import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  OnModuleInit,
+} from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { configModule } from './modules/config.module';
@@ -12,6 +17,7 @@ import { BookReadModule } from '../bookread/bookread.module';
 import { ChallengeModule } from '../challenge/challenge.module';
 import { ReviewModule } from '../review/review.module';
 import { SearchModule } from 'src/search/search.module';
+import { SearchRepository } from 'src/search/search.repository';
 
 @Module({
   imports: [
@@ -29,8 +35,16 @@ import { SearchModule } from 'src/search/search.module';
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule implements NestModule {
+export class AppModule implements NestModule, OnModuleInit {
+  constructor(private readonly searchRepository: SearchRepository) {}
+
   configure(consumer: MiddlewareConsumer) {
     consumer.apply(LoggerMiddleware).forRoutes('*');
+  }
+
+  async onModuleInit() {
+    console.log('데이터베이스에서 책 정보를 Redis로 로딩 중...');
+    await this.searchRepository.loadBooksToRedis();
+    console.log('Redis 로딩 완료!');
   }
 }

--- a/src/book/book.controller.ts
+++ b/src/book/book.controller.ts
@@ -77,6 +77,16 @@ export class BookController {
     return this.bookService.getBooks(query);
   }
 
+  @Post(':bookId/views')
+  @ApiOperation({ summary: '책 조회수 증가' })
+  @ApiNoContentResponse()
+  @HttpCode(204)
+  async incrementBookViews(
+    @Param('bookId', ParseIntPipe) bookId: number,
+  ): Promise<void> {
+    await this.bookService.incrementBookViews(bookId);
+  }
+
   /*
   @Get(':bookId/paragraphs')
   @UseGuards(JwtAuthGuard)

--- a/src/book/book.repository.ts
+++ b/src/book/book.repository.ts
@@ -7,6 +7,7 @@ import { MetadataData } from './type/metadata-data.type';
 import { BookQuery } from './query/book.query';
 import { distributeParagraphs } from './parsing';
 import { ParagraphData } from '../paragraph/type/paragraph-type';
+import { redis } from '../search/redis.provider';
 
 @Injectable()
 export class BookRepository {
@@ -361,5 +362,17 @@ export class BookRepository {
     }
 
     return streak;
+  }
+
+  async incrementBookViews(bookId: number, title: string): Promise<void> {
+    await this.prisma.book.update({
+      where: { id: bookId },
+      data: {
+        views: {
+          increment: 1,
+        },
+      },
+    });
+    await redis.zincrby('autocomplete:views', 1, title);
   }
 }

--- a/src/book/book.service.ts
+++ b/src/book/book.service.ts
@@ -342,4 +342,12 @@ export class BookService {
       return null;
     }
   }
+
+  async incrementBookViews(bookId: number): Promise<void> {
+    const book = await this.bookRepository.getBookById(bookId);
+    if (!book) {
+      throw new NotFoundException('책을 찾을 수 없습니다.');
+    }
+    await this.bookRepository.incrementBookViews(bookId, book.title);
+  }
 }

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -1,11 +1,6 @@
-import { Body, Controller, HttpCode, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post } from '@nestjs/common';
 import { SearchService } from './search.service';
-import {
-  ApiNoContentResponse,
-  ApiOkResponse,
-  ApiOperation,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { SearchPayload } from './payload/search-payload';
 
 @Controller('search')
@@ -13,20 +8,16 @@ import { SearchPayload } from './payload/search-payload';
 export class SearchController {
   constructor(private readonly searchService: SearchService) {}
 
-  @Post('popular')
-  @ApiOperation({
-    summary: '인기 검색어 중 현재 검색어와 매칭되는 것 조회 (내림차순)',
-  })
+  @Post('autocomplete')
+  @ApiOperation({ summary: '자동완성 검색어 조회' })
   @ApiOkResponse({ type: [String] })
-  async getPopular(@Body() payload: SearchPayload): Promise<string[]> {
-    return await this.searchService.getMatchingPopularTerms(payload.query);
-  }
-
-  @Post('increment')
-  @ApiOperation({ summary: '검색어의 검색 횟수 증가' })
-  @ApiNoContentResponse()
-  @HttpCode(204)
-  async incrementSearchTerm(@Body() payload: SearchPayload): Promise<void> {
-    await this.searchService.incrementSearchTerm(payload.query);
+  async getAutocomplete(@Body() searchPayload: SearchPayload) {
+    const { query } = searchPayload;
+    if (!query) {
+      return { lexical: [], views: [] };
+    }
+    const suggestions =
+      await this.searchService.getAutocompleteSuggestions(query);
+    return suggestions;
   }
 }

--- a/src/search/search.module.ts
+++ b/src/search/search.module.ts
@@ -7,5 +7,6 @@ import { BadWordsFilterService } from 'src/auth/bad-words-filter.service';
 @Module({
   controllers: [SearchController],
   providers: [SearchService, SearchRepository, BadWordsFilterService],
+  exports: [SearchRepository],
 })
 export class SearchModule {}

--- a/src/search/search.repository.ts
+++ b/src/search/search.repository.ts
@@ -1,7 +1,56 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../common/services/prisma.service';
+import { redis } from './redis.provider';
 
 @Injectable()
 export class SearchRepository {
   constructor(private readonly prisma: PrismaService) {}
+
+  // Redis에 책 제목과 작가명을 초기 로딩하는 메서드
+  // 이 메서드는 애플리케이션 시작 시 한 번 호출되어야 함
+  async loadBooksToRedis(): Promise<void> {
+    const books = await this.prisma.book.findMany();
+
+    const lexicalSearchKey = 'autocomplete:lexical';
+    const viewsSearchKey = 'autocomplete:views';
+
+    const pipeline = redis.pipeline();
+    for (const book of books) {
+      pipeline.zadd(lexicalSearchKey, 0, book.title);
+      pipeline.zadd(lexicalSearchKey, 0, book.author);
+      pipeline.zadd(viewsSearchKey, book.views, book.title);
+    }
+    await pipeline.exec();
+  }
+
+  // Redis에서 자동완성 검색 결과를 가져오는 메서드
+  async searchAutocomplete(
+    query: string,
+  ): Promise<{ lexical: string[]; views: string[] }> {
+    const lexicalSearchKey = 'autocomplete:lexical';
+    const viewsSearchKey = 'autocomplete:views';
+    const limit = 5;
+
+    // 첫 번째: '포함 문자열' 검색 후 사전식 정렬
+    const allLexicalResults = await redis.zrange(lexicalSearchKey, 0, -1);
+    const filteredLexical = allLexicalResults
+      .filter((member) => member.includes(query)) // 포함 문자열로 필터링
+      .sort((a, b) => a.localeCompare(b, 'ko')) // 한글 사전식 정렬
+      .slice(0, limit); // 5개만 가져오기
+
+    // 두 번째: 조회수 순 검색
+    const allViewsResults = await redis.zrevrangebyscore(
+      viewsSearchKey,
+      '+inf',
+      '-inf',
+    );
+    const filteredViews = allViewsResults
+      .filter((member) => member.includes(query)) // 포함 문자열로 필터링
+      .slice(0, limit); // 5개만 가져오기
+
+    return {
+      lexical: filteredLexical,
+      views: filteredViews,
+    };
+  }
 }


### PR DESCRIPTION
1. 검색어 자동완성 수정
- 자동완성 추천 검색어를 두 가지로 구분 -> 조회수 기준, 검색어가 포함됐는지 여부
- 동일 조건 내에서는 사전식 순서로 앞서는 것들을 가져옴
- 각각 5개, 중복은 처리 안 함

2. 책 조회수 증가 api
- DB 상의 views와 Redis의 조회수 동시에 증가

- 초기 실행 시 Redis에 책 제목과 작가명, 조회수 로딩 추가