### PR TITLE
feat: 책 검색 api 변경

### DIFF
--- a/src/book/book.controller.ts
+++ b/src/book/book.controller.ts
@@ -70,13 +70,6 @@ export class BookController {
     return this.bookService.getBookById(bookId);
   }
 
-  @Get('v1/search')
-  @ApiOperation({ summary: '책 제목과 작가로 책 검색 (둘 중 하나로도 가능)' })
-  @ApiOkResponse({ type: BookListDto })
-  async getBooks(@Query() query: BookQuery): Promise<BookListDto> {
-    return this.bookService.getBooks(query);
-  }
-
   @Post('v1/:bookId/views')
   @ApiOperation({ summary: '책 조회수 증가' })
   @ApiNoContentResponse()

--- a/src/book/book.repository.ts
+++ b/src/book/book.repository.ts
@@ -129,24 +129,6 @@ export class BookRepository {
       },
     });
   }
-
-  async getBooks(query: BookQuery): Promise<BookData[]> {
-    return this.prisma.book.findMany({
-      where: {
-        ...(query.title && { title: query.title }),
-        ...(query.author && { author: query.author }),
-      },
-      select: {
-        id: true,
-        title: true,
-        author: true,
-        isbn: true,
-        views: true,
-        totalParagraphsCount: true,
-      },
-    });
-  }
-
   /*
   async toggleBookLike(bookId: number, userId: number): Promise<void> {
     const like = await this.prisma.bookLike.findUnique({

--- a/src/book/book.service.ts
+++ b/src/book/book.service.ts
@@ -124,11 +124,6 @@ export class BookService {
     return BookDto.from(updatedBook);
   }
 
-  async getBooks(query: BookQuery): Promise<BookListDto> {
-    const books = await this.bookRepository.getBooks(query);
-    return BookListDto.from(books);
-  }
-
   /*
   async toggleBookLike(bookId: number, user: UserBaseInfo): Promise<void> {
     const book = await this.bookRepository.getBookById(bookId);

--- a/src/search/query/book-search-query.ts
+++ b/src/search/query/book-search-query.ts
@@ -1,0 +1,11 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class BookSearchQuery {
+  @IsString()
+  @ApiPropertyOptional({
+    description: '검색어',
+    type: String,
+  })
+  query!: string;
+}

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -1,7 +1,9 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, Get, Query } from '@nestjs/common';
 import { SearchService } from './search.service';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { SearchPayload } from './payload/search-payload';
+import { BookListDto } from 'src/book/dto/book.dto';
+import { BookSearchQuery } from './query/book-search-query';
 
 @Controller('search')
 @ApiTags('Search API')
@@ -19,5 +21,12 @@ export class SearchController {
     const suggestions =
       await this.searchService.getAutocompleteSuggestions(query);
     return suggestions;
+  }
+
+  @Get('v1/search')
+  @ApiOperation({ summary: '책 검색' })
+  @ApiOkResponse({ type: BookListDto })
+  async getBooks(@Query() query: BookSearchQuery): Promise<BookListDto> {
+    return this.searchService.getBooks(query);
   }
 }

--- a/src/search/search.repository.ts
+++ b/src/search/search.repository.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../common/services/prisma.service';
 import { redis } from './redis.provider';
+import { BookData } from 'src/book/type/book-data.type';
+import { BookSearchQuery } from './query/book-search-query';
 
 @Injectable()
 export class SearchRepository {
@@ -52,5 +54,16 @@ export class SearchRepository {
       lexical: filteredLexical,
       views: filteredViews,
     };
+  }
+
+  async getBooks(query: BookSearchQuery): Promise<BookData[]> {
+    return this.prisma.book.findMany({
+      where: {
+        OR: [
+          { title: { contains: query.query, mode: 'insensitive' } },
+          { author: { contains: query.query, mode: 'insensitive' } },
+        ],
+      },
+    });
   }
 }

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { SearchRepository } from './search.repository';
+import { BookListDto } from 'src/book/dto/book.dto';
+import { BookSearchQuery } from './query/book-search-query';
 
 @Injectable()
 export class SearchService {
@@ -17,5 +19,10 @@ export class SearchService {
       lexical: lexical, // 사전식 정렬 목록
       views: views, // 조회수 순 정렬 목록
     };
+  }
+
+  async getBooks(query: BookSearchQuery): Promise<BookListDto> {
+    const books = await this.searchRepository.getBooks(query);
+    return BookListDto.from(books);
   }
 }


### PR DESCRIPTION
- 기존의 책 제목 혹은 작가명을 입력받아 책을 검색하는 api는 검색어가 DB의 책 제목 또는 작가명과 정확히 일치해야 검색이 되었음
- 검색어가 제목 혹은 작가명에 포함된 모든 책을 반환하는 형식으로 변경
- 검색 api의 위치를 Book 모듈에서 Search 모듈로 변경