### PR TITLE
refactor: 프로필 사진 업로드 플로우 변경

### DIFF
--- a/src/user/payload/filepath.payload.ts
+++ b/src/user/payload/filepath.payload.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class FilePathPayload {
+  @IsString()
+  @ApiProperty({
+    description: '파일 경로',
+    type: String,
+  })
+  filePath!: string;
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -8,6 +8,7 @@ import {
   Patch,
   UseGuards,
   ParseIntPipe,
+  Post,
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import {
@@ -22,6 +23,7 @@ import { UpdateUserPayload } from './payload/update-user.payload';
 import { CurrentUser } from '../auth/decorator/user.decorator';
 import { UserBaseInfo } from '../auth/type/user-base-info.type';
 import { ApiTags } from '@nestjs/swagger';
+import { FilePathPayload } from './payload/filepath.payload';
 
 @Controller('users')
 @ApiTags('User API')
@@ -40,8 +42,21 @@ export class UserController {
   })
   async getPresignedUploadUrl(
     @CurrentUser() user: UserBaseInfo,
-  ): Promise<string> {
+  ): Promise<{ url: string; filePath: string }> {
     return this.userService.getPresignedUploadUrl(user);
+  }
+
+  @Post('v1/profile-image/commit')
+  @ApiNoContentResponse()
+  @HttpCode(204)
+  @ApiOperation({ summary: '프로필 사진 업로드 완료 커밋' })
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  async commitProfileImage(
+    @CurrentUser() user: UserBaseInfo,
+    @Body() payload: FilePathPayload,
+  ): Promise<void> {
+    return this.userService.commitProfileImage(user.id, payload.filePath);
   }
 
   @Get('v1/profile-image-url')


### PR DESCRIPTION
- 기존 방식은 사진 업로드에 실패하는 경우에 대하여 고려하지 않음
- presigned 업로드 url만을 반환하는 api와 프로필 사진 업로드 성공 이후 호출하는 커밋 api를 따로 두어 프로필 사진 업로드 실패 시에 기존 프로필 사진을 유지할 수 있게 플로우를 변경함