### PR TITLE
feat: 월별 독서 캘린더 조회 api 구현 & 일부 DTO의 필드명 변경

### DIFF
--- a/src/book/book.service.ts
+++ b/src/book/book.service.ts
@@ -109,7 +109,7 @@ export class BookService {
       title: payload.title,
       author: payload.author,
       isbn: payload.isbn ?? null,
-      totalPagesCount: payload.totalPagesCount,
+      totalPagesCount: payload.totalPages,
     };
 
     const updatedBook = await this.bookRepository.updateBook(bookId, data);

--- a/src/book/dto/book.dto.ts
+++ b/src/book/dto/book.dto.ts
@@ -37,7 +37,7 @@ export class BookDto {
     description: '총 페이지 수',
     type: Number,
   })
-  totalPagesCount!: number;
+  totalPages!: number;
 
   static from(data: BookData): BookDto {
     return {
@@ -46,7 +46,7 @@ export class BookDto {
       author: data.author,
       isbn: data.isbn,
       views: data.views,
-      totalPagesCount: data.totalPagesCount,
+      totalPages: data.totalPagesCount,
     };
   }
 

--- a/src/book/payload/patch-update-book.payload.ts
+++ b/src/book/payload/patch-update-book.payload.ts
@@ -33,5 +33,5 @@ export class PatchUpdateBookPayload {
     description: '총 페이지 수',
     type: Number,
   })
-  totalPagesCount?: number;
+  totalPages?: number;
 }

--- a/src/book/payload/save-book.payload.ts
+++ b/src/book/payload/save-book.payload.ts
@@ -27,5 +27,5 @@ export class SaveBookPayload {
     description: '총 문단 수',
     type: Number,
   })
-  totalPagesCount!: number;
+  totalPages!: number;
 }

--- a/src/challenge/dto/participant.dto.ts
+++ b/src/challenge/dto/participant.dto.ts
@@ -10,7 +10,7 @@ export class ParticipantDto {
   @ApiProperty({
     description: '참여자 이름',
   })
-  name!: string;
+  nickname!: string;
 
   @ApiProperty({
     description: '최대 페이지',
@@ -25,7 +25,7 @@ export class ParticipantDto {
   static from(data: ParticipantData): ParticipantDto {
     return {
       id: data.id,
-      name: data.name,
+      nickname: data.name,
       maxPageRead: data.maxPageRead,
       lastLoginAt: data.lastLoginAt,
     };

--- a/src/page/dto/page.dto.ts
+++ b/src/page/dto/page.dto.ts
@@ -52,7 +52,7 @@ export class PageListDto {
     description: '페이지 총 개수',
     type: Number,
   })
-  totalPagesCount!: number;
+  totalPages!: number;
 
   @ApiProperty({
     description: '페이지 목록',
@@ -67,7 +67,7 @@ export class PageListDto {
   ): PageListDto {
     return {
       book,
-      totalPagesCount,
+      totalPages: totalPagesCount,
       pages: PageDto.fromArray(pages),
     };
   }

--- a/src/read/dto/reading-progress.dto.ts
+++ b/src/read/dto/reading-progress.dto.ts
@@ -28,7 +28,7 @@ export class ReadingProgressDto {
 
   static from(data: ReadingProgressData): ReadingProgressDto {
     return {
-      book: data.book,
+      book: BookDto.from(data.book),
       maxPageRead: data.maxPageRead,
       progress: data.progress,
       challengeParticipation: data.challengeParticipation,

--- a/src/read/query/calendar.query.ts
+++ b/src/read/query/calendar.query.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt } from 'class-validator';
+
+export class CalendarQuery {
+  @IsInt()
+  @Type(() => Number)
+  @ApiProperty({
+    description: '연도',
+    type: Number,
+  })
+  year!: number;
+
+  @IsInt()
+  @Type(() => Number)
+  @ApiProperty({
+    description: '월',
+    type: Number,
+  })
+  month!: number;
+}

--- a/src/read/read.controller.ts
+++ b/src/read/read.controller.ts
@@ -27,11 +27,25 @@ import { CreateReadingEndLogPayload } from './payload/create-reading-end-log.pay
 import { ReadingLogDto, ReadingLogListDto } from './dto/reading-log.dto';
 import { DateQuery } from './query/date.query';
 import { ReadingProgressListDto } from './dto/reading-progress.dto';
+import { CalendarQuery } from './query/calendar.query';
 
 @Controller('read')
 @ApiTags('Read API')
 export class ReadController {
   constructor(private readonly readService: ReadService) {}
+
+  @Get('calendar')
+  @Version('1')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '유저의 독서 캘린더 조회' })
+  @ApiOkResponse({ type: [String] })
+  async getReadingCalendar(
+    @Query() calendarQuery: CalendarQuery,
+    @CurrentUser() user: UserBaseInfo,
+  ): Promise<string[]> {
+    return this.readService.getReadingCalendar(calendarQuery, user);
+  }
 
   @Get('date')
   @Version('1')

--- a/src/read/read.repository.ts
+++ b/src/read/read.repository.ts
@@ -218,4 +218,24 @@ export class ReadRepository {
     });
     return participation !== null;
   }
+
+  async getMonthlyReadingLogs(
+    monthStart: Date,
+    monthEnd: Date,
+    user: UserBaseInfo,
+  ) {
+    return this.prisma.readingLog.findMany({
+      where: {
+        userId: user.id,
+        OR: [
+          { startedAt: { gte: monthStart, lte: monthEnd } },
+          { endedAt: { gte: monthStart, lte: monthEnd } },
+        ],
+      },
+      select: {
+        startedAt: true,
+        endedAt: true,
+      },
+    });
+  }
 }


### PR DESCRIPTION
1. 월별 독서 캘린더 조회 api 구현

2. 책 DTO에서 총 페이지 수 필드명을 totalPagesCount에서 totalPages로 변경

3. 챌린지 참가자 DTO에서 참가자의 닉네임의 필드명을 name에서 nickname으로 변경