### PR TITLE
chore: 단순 조회 api 롤백, 랭킹 조회 갯수 변경

### DIFF
--- a/src/book/book.controller.ts
+++ b/src/book/book.controller.ts
@@ -148,6 +148,14 @@ export class BookController {
     return this.bookService.getBookSuggestions();
   }
 
+  @Get(':id')
+  @Version('1')
+  @ApiOperation({ summary: '책 조회' })
+  @ApiOkResponse({ type: BookDto })
+  async getBookById(@Param('id', ParseIntPipe) id: number): Promise<BookDto> {
+    return this.bookService.getBookById(id);
+  }
+
   @Post(':id/complete')
   @Version('1')
   @ApiBearerAuth()

--- a/src/book/ranking.service.ts
+++ b/src/book/ranking.service.ts
@@ -15,7 +15,7 @@ export class RankingService {
   async getBookRankings(): Promise<BookRankingListDto> {
     // 1. 최신 랭킹 데이터를 가져옵니다.
     const latestRankings: BookRankingData[] =
-      await this.rankingRepository.findLatestRankings(10);
+      await this.rankingRepository.findLatestRankings(9);
     if (latestRankings.length === 0) return BookRankingListDto.from([]);
 
     const latestBookIds = latestRankings.map((r) => r.book.id);

--- a/src/read/read.controller.ts
+++ b/src/read/read.controller.ts
@@ -63,7 +63,10 @@ export class ReadController {
   @Version('1')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: '책의 마지막으로 진입한 페이지 조회 (이어읽기)' })
+  @ApiOperation({
+    summary: '책의 마지막으로 진입한 페이지 조회 (이어읽기)',
+    description: 'id는 책의 ID입니다.',
+  })
   @ApiOkResponse({ type: LastPageDto })
   async getLastPage(
     @Param('id', ParseIntPipe) id: number,

--- a/src/sentence-like/sentence-like.controller.ts
+++ b/src/sentence-like/sentence-like.controller.ts
@@ -42,6 +42,16 @@ export class SentenceLikeController {
     return this.sentenceLikeService.createSentenceLike(payload, user);
   }
 
+  @Get(':id')
+  @Version('1')
+  @ApiOperation({ summary: '문장 좋아요 조회' })
+  @ApiOkResponse({ type: SentenceLikeDto })
+  async getSentenceLikeById(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<SentenceLikeDto> {
+    return this.sentenceLikeService.getSentenceLikeById(id);
+  }
+
   @Delete(':id')
   @Version('1')
   @ApiBearerAuth()

--- a/src/sentence-like/sentence-like.service.ts
+++ b/src/sentence-like/sentence-like.service.ts
@@ -73,4 +73,12 @@ export class SentenceLikeService {
 
     return this.sentenceLikeRepository.deleteSentenceLike(id);
   }
+
+  async getSentenceLikeById(id: number): Promise<SentenceLikeDto> {
+    const like = await this.sentenceLikeRepository.getSentenceLikeById(id);
+    if (!like) {
+      throw new NotFoundException('문장 좋아요를 찾을 수 없습니다.');
+    }
+    return SentenceLikeDto.from(like);
+  }
 }


### PR DESCRIPTION
- 책, 문장 좋아요의 단순 조회 api 롤백
- 랭킹 조회 갯수를 10개에서 9개로 변경